### PR TITLE
Update for broken reports

### DIFF
--- a/database/models.py
+++ b/database/models.py
@@ -125,7 +125,7 @@ class Report(Base):
             except Exception:
                 self.text = ""
                 self.creation_date = datetime.datetime.fromisoformat('2011-11-11 04:20:33')
-                self.hash = ""
+                self.hash = hashlib.md5(str(datetime.datetime.now()).encode()).hexdigest()  # секунды с милисекундами, совпасть не может
                 self.is_broken = True
         self.set_grade()
 

--- a/database/models.py
+++ b/database/models.py
@@ -117,10 +117,16 @@ class Report(Base):
             self.creation_date = self.get_report_date(file)
             self.hash = hashlib.md5(file.extractfile('./TIME.txt').read()).hexdigest()
         except Exception:
-            self.text = ""
-            self.creation_date = datetime.datetime.fromisoformat('2011-11-11 04:20:33')
-            self.hash = ""
-            self.is_broken = True
+            try:
+                file = tarfile.open(file_path)
+                self.text = file.extractfile('./OUT.txt').read().decode('cp1251')
+                self.creation_date = self.get_report_date(file)
+                self.hash = hashlib.md5(file.extractfile('./TIME.txt').read()).hexdigest()
+            except Exception:
+                self.text = ""
+                self.creation_date = datetime.datetime.fromisoformat('2011-11-11 04:20:33')
+                self.hash = ""
+                self.is_broken = True
         self.set_grade()
 
     def __repr__(self):


### PR DESCRIPTION
Now if it's unable to decode report as utf-8, program will try to decode it as cp1251. Now all broken reports also have hash, so they are not plagiary